### PR TITLE
switch from review status to rejection boolean

### DIFF
--- a/cmd/events-sync/main.go
+++ b/cmd/events-sync/main.go
@@ -120,16 +120,21 @@ func databaseEventToEvent(dbEvent database.Event) event.Event {
 }
 
 func showReviewStatusSummary(db *database.DB) error {
-	fmt.Println("\n=== Review Status Summary ===")
+	fmt.Println("\n=== Rejected Status Summary ===")
 
-	statuses := []string{"pending", "reviewed", "rejected"}
-	for _, status := range statuses {
-		events, err := db.GetEventsByReviewStatus(status)
-		if err != nil {
-			return fmt.Errorf("failed to get events with status %s: %v", status, err)
-		}
-		fmt.Printf("%s: %d events\n", status, len(events))
+	// Get rejected events
+	rejectedEvents, err := db.GetEventsByRejectedStatus(true)
+	if err != nil {
+		return fmt.Errorf("failed to get rejected events: %v", err)
 	}
+	fmt.Printf("rejected: %d events\n", len(rejectedEvents))
+
+	// Get non-rejected events
+	nonRejectedEvents, err := db.GetEventsByRejectedStatus(false)
+	if err != nil {
+		return fmt.Errorf("failed to get non-rejected events: %v", err)
+	}
+	fmt.Printf("approved: %d events\n", len(nonRejectedEvents))
 
 	return nil
 }

--- a/internal/server/event_handlers_test.go
+++ b/internal/server/event_handlers_test.go
@@ -25,7 +25,7 @@ func TestGenerateICalContent(t *testing.T) {
 			Location:     &location1,
 			StartTime:    time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC),
 			EndTime:      time.Date(2025, 1, 1, 13, 0, 0, 0, time.UTC),
-			ReviewStatus: "pending",
+			Rejected:     false,
 			CreatedAt:    time.Date(2024, 12, 1, 10, 0, 0, 0, time.UTC),
 			UpdatedAt:    time.Date(2024, 12, 1, 10, 0, 0, 0, time.UTC),
 		},
@@ -38,7 +38,7 @@ func TestGenerateICalContent(t *testing.T) {
 			Location:     nil,
 			StartTime:    time.Date(2025, 1, 2, 14, 0, 0, 0, time.UTC),
 			EndTime:      time.Date(2025, 1, 2, 15, 0, 0, 0, time.UTC),
-			ReviewStatus: "reviewed",
+			Rejected:     false,
 			CreatedAt:    time.Date(2024, 12, 1, 11, 0, 0, 0, time.UTC),
 			UpdatedAt:    time.Date(2024, 12, 1, 11, 0, 0, 0, time.UTC),
 		},
@@ -51,7 +51,7 @@ func TestGenerateICalContent(t *testing.T) {
 			Location:     nil,
 			StartTime:    time.Date(2025, 1, 3, 16, 0, 0, 0, time.UTC),
 			EndTime:      time.Date(2025, 1, 3, 17, 0, 0, 0, time.UTC),
-			ReviewStatus: "rejected",
+			Rejected:     true,
 			CreatedAt:    time.Date(2024, 12, 1, 12, 0, 0, 0, time.UTC),
 			UpdatedAt:    time.Date(2024, 12, 1, 12, 0, 0, 0, time.UTC),
 		},
@@ -133,11 +133,11 @@ func TestGenerateICalContent(t *testing.T) {
 	if !strings.Contains(icalContent, "LOCATION:Test Location") {
 		t.Error("Missing first event location")
 	}
-	if !strings.Contains(icalContent, "X-REVIEW-STATUS:pending") {
-		t.Error("Missing first event review status")
+	if !strings.Contains(icalContent, "X-REJECTED:false") {
+		t.Error("Missing first event rejected status")
 	}
-	if !strings.Contains(icalContent, "X-REVIEW-STATUS:reviewed") {
-		t.Error("Missing second event review status")
+	if !strings.Contains(icalContent, "X-REJECTED:false") {
+		t.Error("Missing second event rejected status")
 	}
 
 	// Verify organization field format change

--- a/migrations/000002_change_review_status_to_rejected.down.sql
+++ b/migrations/000002_change_review_status_to_rejected.down.sql
@@ -1,0 +1,15 @@
+-- Revert: Add back review_status column
+ALTER TABLE events ADD COLUMN review_status VARCHAR(20) DEFAULT 'pending' CHECK (review_status IN ('reviewed', 'rejected', 'pending'));
+
+-- Migrate data back: set review_status based on rejected value
+UPDATE events SET review_status = 'rejected' WHERE rejected = true;
+UPDATE events SET review_status = 'reviewed' WHERE rejected = false;
+
+-- Drop the rejected column
+ALTER TABLE events DROP COLUMN rejected;
+
+-- Drop the new index
+DROP INDEX IF EXISTS idx_events_rejected;
+
+-- Recreate the old index
+CREATE INDEX IF NOT EXISTS idx_events_review_status ON events(review_status);

--- a/migrations/000002_change_review_status_to_rejected.up.sql
+++ b/migrations/000002_change_review_status_to_rejected.up.sql
@@ -1,0 +1,14 @@
+-- Change review_status column to rejected boolean
+ALTER TABLE events ADD COLUMN rejected BOOLEAN DEFAULT FALSE;
+
+-- Migrate existing data: set rejected = true for events with review_status = 'rejected'
+UPDATE events SET rejected = true WHERE review_status = 'rejected';
+
+-- Drop the old review_status column
+ALTER TABLE events DROP COLUMN review_status;
+
+-- Drop the old index
+DROP INDEX IF EXISTS idx_events_review_status;
+
+-- Create new index for rejected status
+CREATE INDEX IF NOT EXISTS idx_events_rejected ON events(rejected);

--- a/web/index.html
+++ b/web/index.html
@@ -21,20 +21,7 @@
         </div>
 
         <!-- Stats Cards -->
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
-            <div class="bg-white rounded-lg shadow p-6">
-                <div class="flex items-center">
-                    <div class="p-2 bg-yellow-100 rounded-lg">
-                        <svg class="w-6 h-6 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                        </svg>
-                    </div>
-                    <div class="ml-4">
-                        <p class="text-sm font-medium text-gray-600">Pending</p>
-                        <p class="text-2xl font-semibold text-gray-900" x-text="stats.pending || 0"></p>
-                    </div>
-                </div>
-            </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
             <div class="bg-white rounded-lg shadow p-6">
                 <div class="flex items-center">
                     <div class="p-2 bg-green-100 rounded-lg">
@@ -43,8 +30,8 @@
                         </svg>
                     </div>
                     <div class="ml-4">
-                        <p class="text-sm font-medium text-gray-600">Reviewed</p>
-                        <p class="text-2xl font-semibold text-gray-900" x-text="stats.reviewed || 0"></p>
+                        <p class="text-sm font-medium text-gray-600">Approved</p>
+                        <p class="text-2xl font-semibold text-gray-900" x-text="stats.approved || 0"></p>
                     </div>
                 </div>
             </div>
@@ -83,9 +70,8 @@
                             Refresh
                         </button>
                         <select x-model="statusFilter" @change="filterEvents()" class="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
-                            <option value="">All Statuses</option>
-                            <option value="pending">Pending</option>
-                            <option value="reviewed">Reviewed</option>
+                            <option value="">All Events</option>
+                            <option value="approved">Approved</option>
                             <option value="rejected">Rejected</option>
                         </select>
                     </div>
@@ -118,10 +104,20 @@
                                 <div class="flex flex-col lg:flex-row lg:items-center justify-between gap-4">
                                     <div class="flex-1">
                                         <div class="flex items-start justify-between mb-2">
-                                            <h4 class="text-lg font-medium text-gray-900" x-text="event.summary"></h4>
-                                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border"
-                                                  :class="getStatusClass(event.review_status)"
-                                                  x-text="event.review_status"></span>
+                                            <h4 class="text-lg font-medium text-gray-900"
+                                                :class="{ 'italic': event.rejected }"
+                                                x-text="event.summary"></h4>
+                                            <div class="flex items-center gap-2">
+                                                <input type="checkbox"
+                                                       :id="'checkbox-' + event.uid"
+                                                       :checked="!event.rejected"
+                                                       @change="updateEventStatus(event.uid, $event.target.checked)"
+                                                       class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 focus:ring-2">
+                                                <label :for="'checkbox-' + event.uid" class="text-sm text-gray-600">
+                                                    <span x-show="!event.rejected">Approved</span>
+                                                    <span x-show="event.rejected" class="text-red-600">Rejected</span>
+                                                </label>
+                                            </div>
                                         </div>
                                         <div class="text-sm text-gray-600 space-y-1">
                                             <p><strong>Organization:</strong> <span x-text="event.organization"></span></p>
@@ -134,17 +130,7 @@
                                             </template>
                                         </div>
                                     </div>
-                                    <div class="flex flex-col sm:flex-row gap-2">
-                                        <select :id="'status-' + event.uid" class="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
-                                            <option value="pending" :selected="event.review_status === 'pending'">Pending</option>
-                                            <option value="reviewed" :selected="event.review_status === 'reviewed'">Reviewed</option>
-                                            <option value="rejected" :selected="event.review_status === 'rejected'">Rejected</option>
-                                        </select>
-                                        <button @click="updateEventStatus(event.uid)"
-                                                class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
-                                            Update
-                                        </button>
-                                    </div>
+
                                 </div>
                             </div>
                         </template>


### PR DESCRIPTION
It doesn't really make sense to differentiate between "pending" and "approved" events, so just assume they're all approved unless they're explicitly rejected. This PR switches the review status to instead be a rejected boolean
